### PR TITLE
Update admin upload card link

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -36,7 +36,7 @@ export default async function AdminPage() {
         </header>
 
         <section className="grid gap-4 sm:grid-cols-2">
-          <Card href="/upload" title="Upload statement" desc="Parse a bank statement PDF and store transactions." />
+          <Card href="/admin/upload" title="Upload statement" desc="Parse a bank statement PDF and store transactions." />
           <Card href="/admin/categories" title="Manage categories" desc="Create, edit or delete categories." />
           <Card href="/admin/users" title="Manage users" desc="Create, edit or delete app users." />
           <Card href="/reports" title="Reports" desc="View monthly summaries and category breakdowns." />


### PR DESCRIPTION
## Summary
- point the Admin dashboard upload card to the `/admin/upload` route so it lands on the correct form

## Testing
- Manual verification: visited `/admin/upload` in the dev server to confirm the upload form renders

------
https://chatgpt.com/codex/tasks/task_e_68caa66d10c48324be5359fc5dbbe461