### PR TITLE
Align Supabase client typing

### DIFF
--- a/src/app/api/statements/create/route.ts
+++ b/src/app/api/statements/create/route.ts
@@ -10,7 +10,7 @@ import { supabaseServerAdmin } from '@/lib/supabaseServer';
 type ParsePdfFn = (buffer: Buffer) => Promise<{ text?: string }>; // compatible with pdf-parse result
 
 export type StatementUploadDependencies = {
-  createSupabaseClient: () => SupabaseClient<unknown, unknown, unknown>;
+  createSupabaseClient: () => SupabaseClient;
   parsePdf: ParsePdfFn;
   now: () => Date;
 };
@@ -49,7 +49,7 @@ function createMockDependencies(): StatementUploadDependencies {
   };
 
   return {
-    createSupabaseClient: () => client as unknown as SupabaseClient<unknown, unknown, unknown>,
+    createSupabaseClient: () => client as unknown as SupabaseClient,
     parsePdf: async () => ({ text: '2024-01-01 Mock Transaction +100.00' }),
     now: () => new Date(),
   };


### PR DESCRIPTION
## Summary
- update the statement upload dependencies to return a generically typed Supabase client without redundant parameters
- align the mock dependency casting with the simplified Supabase client type

## Testing
- npm run build *(fails: Next.js Turbopack could not download Google Fonts due to network restrictions in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cac9ddd4788324827d37d0583140b3