### PR TITLE
Fix health check service role key

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -5,6 +5,7 @@ export async function GET() {
   return NextResponse.json({
     hasUrl: Boolean(process.env.NEXT_PUBLIC_SUPABASE_URL),
     hasAnon: Boolean(process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY),
-    hasServiceRole: Boolean(process.env.SUPABASE_SERVICE_ROLE),
+    hasServiceRoleKey: Boolean(process.env.SUPABASE_SERVICE_ROLE_KEY),
+    hasServiceRole: Boolean(process.env.SUPABASE_SERVICE_ROLE_KEY),
   });
 }


### PR DESCRIPTION
## Summary
- report the SUPABASE_SERVICE_ROLE_KEY environment variable in the health endpoint
- retain the hasServiceRole field while adding hasServiceRoleKey for compatibility

## Testing
- NEXT_DISABLE_FONT_OPTIMIZATION=1 npm run build *(fails: next/font could not download Google Fonts in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68cad281e29c8324908dde028ca0c7dc