### PR TITLE
refactor: lazily load pdf parser in API routes

### DIFF
--- a/src/app/api/parse/route.ts
+++ b/src/app/api/parse/route.ts
@@ -1,9 +1,10 @@
 // src/app/api/parse/route.ts (only the imports shown here)
-import { NextRequest, NextResponse } from 'next/server';
-import pdf from 'pdf-parse';
-import { sha256 } from 'js-sha256';
-import { supabaseServerAdmin } from '@/lib/supabaseServer';
+export const runtime = 'nodejs';
 
+import { NextRequest, NextResponse } from 'next/server';
+import { sha256 } from 'js-sha256';
+import { getPdfParse } from '@/lib/pdfParse';
+import { supabaseServerAdmin } from '@/lib/supabaseServer';
 
 export async function POST(req: NextRequest) {
   try {
@@ -34,7 +35,8 @@ export async function POST(req: NextRequest) {
     // Parse the PDF file
     const pdfArrayBuffer = await fileData.arrayBuffer();
     const pdfBuffer = Buffer.from(pdfArrayBuffer);
-    const pdfText = await pdf(pdfBuffer);
+    const parsePdf = await getPdfParse();
+    const pdfText = await parsePdf(pdfBuffer);
 
     // TODO: Implement actual parsing logic
     const newStatements = [];


### PR DESCRIPTION
## Summary
- add a shared pdf-parse loader that caches the dynamic import and reports friendly errors
- update the statements create handler to request the parser at request time while keeping mockable dependencies
- switch the parse API route to use the shared loader and mark it as node runtime

## Testing
- npm run lint
- npm test
- MOCK_SUPABASE=1 npm run dev (manual)
- curl -s -D - -o - -F "file=@/tmp/sample.pdf;type=application/pdf" -F "accountName=Checking" http://localhost:3000/api/statements/create
- curl -s -D - -o - -X POST -H 'Content-Type: application/json' -d '{"statementId":"statement.pdf"}' http://localhost:3000/api/parse

------
https://chatgpt.com/codex/tasks/task_e_68cad899220c8324975585f6ce795578