### PR TITLE
Fix pdf parser import path

### DIFF
--- a/src/lib/pdfParse.ts
+++ b/src/lib/pdfParse.ts
@@ -11,8 +11,8 @@ export async function getPdfParse(): Promise<PdfParseFn> {
   if (!loadingParserPromise) {
     loadingParserPromise = (async () => {
       try {
-        const pdfModule = await import('pdf-parse');
-        const parser = pdfModule?.default;
+        const pdfModule = await import('pdf-parse/lib/pdf-parse.js');
+        const parser = pdfModule?.default ?? pdfModule;
 
         if (typeof parser !== 'function') {
           throw new Error('`pdf-parse` default export is not a function');

--- a/types/pdf-parse.d.ts
+++ b/types/pdf-parse.d.ts
@@ -1,0 +1,6 @@
+import type { PdfParseFn } from '../src/lib/pdfParse';
+
+declare module 'pdf-parse/lib/pdf-parse.js' {
+  const pdfParse: PdfParseFn;
+  export default pdfParse;
+}


### PR DESCRIPTION
## Summary
- load the pdf-parse implementation from pdf-parse/lib/pdf-parse.js and cache the callable export without invoking the debug bootstrap
- add a module declaration for pdf-parse/lib/pdf-parse.js so the parser continues to be typed as PdfParseFn

## Testing
- npm run test -- statements
- npx tsx /tmp/manual-upload.ts


------
https://chatgpt.com/codex/tasks/task_e_68cadfbf6448832486f74956552ef8ed