### PR TITLE
Move pdf-parse type declaration into package folder

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     ],
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "typeRoots": ["./types", "./node_modules/@types"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/types/pdf-parse/index.d.ts
+++ b/types/pdf-parse/index.d.ts
@@ -1,5 +1,4 @@
-import type { PdfParseFn } from '../src/lib/pdfParse';
-
+import type { PdfParseFn } from '../../src/lib/pdfParse';
 declare module 'pdf-parse/lib/pdf-parse.js' {
   const pdfParse: PdfParseFn;
   export default pdfParse;


### PR DESCRIPTION
## Summary
- move the pdf-parse type declaration to types/pdf-parse/index.d.ts so it mirrors the runtime entry point
- configure TypeScript typeRoots to include the custom types directory alongside @types packages

## Testing
- npm run build *(fails: Next.js cannot download Google Fonts in the sandboxed environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb659936d08324a75627f32ff6dfa0