### PR TITLE
Add ambient declaration for pdf-parse bundler resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,12 @@
     },
     "typeRoots": ["./types", "./node_modules/@types"]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "types/**/*.d.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/types/pdf-parse-lib.d.ts
+++ b/types/pdf-parse-lib.d.ts
@@ -1,4 +1,5 @@
-import type { PdfParseFn } from '../../src/lib/pdfParse';
+import type { PdfParseFn } from '../src/lib/pdfParse';
+
 declare module 'pdf-parse/lib/pdf-parse.js' {
   const pdfParse: PdfParseFn;
   export default pdfParse;


### PR DESCRIPTION
## Summary
- add a top-level declaration file to type the `pdf-parse/lib/pdf-parse.js` module with the existing `PdfParseFn`
- extend the TypeScript include list so ambient `types/**/*.d.ts` files are picked up with bundler module resolution

## Testing
- npm run build *(fails: Next.js Turbopack cannot fetch Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb93e7dc8c83248ab514bcd7168bbe